### PR TITLE
Fixing the quotes around the AMI id.

### DIFF
--- a/bin/in
+++ b/bin/in
@@ -15,7 +15,7 @@ export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' /tmp/input)
 aws ec2 describe-images --image-ids "$AMI" --query 'Images[0]' \
   | tee "$DEST/output.json"
 
-jq '.ImageId' < "$DEST/output.json" > "$DEST/id"
+jq -r '.ImageId' < "$DEST/output.json" > "$DEST/id"
 
 jq '{source_ami: .ImageId}' < "$DEST/output.json" > "$DEST/packer.json"
 


### PR DESCRIPTION
Sorry this took a little while. I built the docker image from this change, pushed it to our Docker Hub, and tested with our Concourse pipeline. Looks to be working.

Ref: #1 