### PR TITLE
Allow AWS cli to authenticate with fallback methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Concourse CI resource to check for new Amazon Machine Images (AMI).
 
 - `filters`: *Required.* A map of named filters to their values. Check the AWS CLI [describe-images](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html) documentation for a complete list of acceptable filters and values.
 
-If `aws_access_key_id` and `aws_secret_access_key` are both absent, AWS CLI will fallback to other authentication mechanisms. See [Configuration setting and precedence](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence)
+If `aws_access_key_id` and `aws_secret_access_key` are both absent, AWS CLI will fall back to other authentication mechanisms. See [Configuration setting and precedence](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence)
 
 ## Behaviour
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ A Concourse CI resource to check for new Amazon Machine Images (AMI).
 
 ## Source Configuration
 
-- `aws_access_key_id`: *Required.* Your AWS access key ID.
+- `aws_access_key_id`: Your AWS access key ID.
 
-- `aws_secret_access_key`: *Required.* Your AWS secret access key.
+- `aws_secret_access_key`: Your AWS secret access key. 
 
 - `region`: *Required.* The AWS region to search for AMIs.
 
 - `filters`: *Required.* A map of named filters to their values. Check the AWS CLI [describe-images](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html) documentation for a complete list of acceptable filters and values.
+
+If `aws_access_key_id` and `aws_secret_access_key` are both absent, AWS CLI will fallback to other authentication mechanisms. See [Configuration setting and precedence](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence)
 
 ## Behaviour
 

--- a/bin/check
+++ b/bin/check
@@ -8,7 +8,7 @@ AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
 AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
 AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
-if [ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" ]; then
+if [ -n "${AWS_ACCESS_KEY_ID}"] && [-n "${AWS_SECRET_ACCESS_KEY}" ]; then
     export AWS_ACCESS_KEY_ID
     export AWS_SECRET_ACCESS_KEY
 fi

--- a/bin/check
+++ b/bin/check
@@ -8,7 +8,7 @@ AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
 AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
 AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
-if [ -n "${AWS_ACCESS_KEY_ID}"] && [-n "${AWS_SECRET_ACCESS_KEY}" ]; then
+if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
     export AWS_ACCESS_KEY_ID
     export AWS_SECRET_ACCESS_KEY
 fi

--- a/bin/check
+++ b/bin/check
@@ -6,8 +6,12 @@ cat | jq . <&0 > /tmp/input
 
 AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
-export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
-export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
+AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+if [ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" ]; then
+    export AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY
+fi
 export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' /tmp/input)
 
 jq '.source.filters | to_entries | map({"Name": .key, "Values": [(.value|select(type!="array") = [.])|.[]|tostring]})' /tmp/input > /tmp/filters.json

--- a/bin/in
+++ b/bin/in
@@ -10,7 +10,7 @@ AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
 AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
 AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
-if [ -n "${AWS_ACCESS_KEY_ID}"] && [-n "${AWS_SECRET_ACCESS_KEY}" ]; then
+if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
     export AWS_ACCESS_KEY_ID
     export AWS_SECRET_ACCESS_KEY
 fi

--- a/bin/in
+++ b/bin/in
@@ -8,8 +8,12 @@ DEST="$1"
 
 AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
-export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
-export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
+AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+if [ -n "${AWS_ACCESS_KEY_ID}"] && [-n "${AWS_SECRET_ACCESS_KEY}" ]; then
+    export AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY
+fi
 export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' /tmp/input)
 
 aws ec2 describe-images --image-ids "$AMI" --query 'Images[0]' \


### PR DESCRIPTION
If `aws_access_key_id` and `aws_secret_access_key` are both absent, AWS CLI will fall back to other authentication mechanisms. See [Configuration setting and precedence](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence)

Built and tested with https://hub.docker.com/r/vlfig/ami-resource/.