### PR TITLE
Enable cross account lookup for AMIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A Concourse CI resource to check for new Amazon Machine Images (AMI).
 
 ## Source Configuration
 
+If you want to assume a role and lookup an AMI in another account, use:
+
+- `role_id`: Your AWS role to assume. Make sure concourse can assume this role.
+
+- `account_id`: The AWS account ID where you want to look up the AMI.
+
+Note: both needs to be set.
+
+Else, use:
+
 - `aws_access_key_id`: Your AWS access key ID.
 
 - `aws_secret_access_key`: Your AWS secret access key. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Concourse CI resource to check for new Amazon Machine Images (AMI).
 
 If you want to assume a role and lookup an AMI in another account, use:
 
-- `role_id`: Your AWS role to assume. Make sure concourse can assume this role.
+- `role_id`: Your AWS role to assume. Make sure your concourse worker can assume this role.
 
 - `account_id`: The AWS account ID where you want to look up the AMI.
 

--- a/bin/check
+++ b/bin/check
@@ -6,9 +6,17 @@ cat | jq . <&0 > /tmp/input
 
 AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
-export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
-export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+export ROLE_ID=$(jq -r '.source.role_id // empty' /tmp/input)
+export ACCOUNT_ID=$(jq -r '.source.account_id // empty' /tmp/input)
 export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' /tmp/input)
+
+if [ ! -z "ACCOUNT_ID" ] && [ ! -z "ROLE_ID" ]; then
+  export temp_credentials=$(aws sts assume-role --role-arn arn:aws:iam::$ACCOUNT_ID:role/$ROLE_ID --role-session-name cc-ami-resource-session)
+  export AWS_ACCESS_KEY_ID=$(echo ${temp_credentials} | jq -r '.Credentials.AccessKeyId') AWS_SESSION_TOKEN=$(echo ${temp_credentials} | jq -r '.Credentials.SessionToken') AWS_SECRET_ACCESS_KEY=$(echo ${temp_credentials} | jq -r ' .Credentials.SecretAccessKey') AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
+else
+  export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
+  export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+fi
 
 # remove any empty credentials vars so the AWS client will try instance profiles
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then

--- a/bin/in
+++ b/bin/in
@@ -8,9 +8,18 @@ DEST="$1"
 
 AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
-export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
-export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+
+export ROLE_ID=$(jq -r '.source.role_id // empty' /tmp/input)
+export ACCOUNT_ID=$(jq -r '.source.account_id // empty' /tmp/input)
 export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' /tmp/input)
+
+if [ ! -z "ACCOUNT_ID" ] && [ ! -z "ROLE_ID" ]; then
+  export temp_credentials=$(aws sts assume-role --role-arn arn:aws:iam::$ACCOUNT_ID:role/$ROLE_ID --role-session-name cc-ami-resource-session)
+  export AWS_ACCESS_KEY_ID=$(echo ${temp_credentials} | jq -r '.Credentials.AccessKeyId') AWS_SESSION_TOKEN=$(echo ${temp_credentials} | jq -r '.Credentials.SessionToken') AWS_SECRET_ACCESS_KEY=$(echo ${temp_credentials} | jq -r ' .Credentials.SecretAccessKey') AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
+else
+  export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
+  export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+fi
 
 # remove any empty credentials vars so the AWS client will try instance profiles
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then


### PR DESCRIPTION
Enable crossaccount lookup when passing in the ROLE_ID and ACCOUNT_ID variable. When not passing them, use it as default.
