### PR TITLE
Add aws_session_token variable to support temporary AWS credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ A Concourse CI resource to check for new Amazon Machine Images (AMI).
 
 - `aws_secret_access_key`: Your AWS secret access key. 
 
+- `aws_session_token`: Your AWS session token (Optional).
+
 - `region`: *Required.* The AWS region to search for AMIs.
 
 - `filters`: *Required.* A map of named filters to their values. Check the AWS CLI [describe-images](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html) documentation for a complete list of acceptable filters and values.
 
-If `aws_access_key_id` and `aws_secret_access_key` are both absent, AWS CLI will fall back to other authentication mechanisms. See [Configuration setting and precedence](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence)
+If `aws_access_key_id`, `aws_secret_access_key` and `aws_session_token` are all absent, AWS CLI will fall back to other authentication mechanisms. See [Configuration setting and precedence](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence)
 
 ## Behaviour
 
@@ -60,6 +62,7 @@ resources:
   source:
     aws_access_key_id: "..."
     aws_secret_access_key: "..."
+    aws_session_token: "..."
     region: ap-southeast-2
     filters:
       owner-id: "099720109477"

--- a/bin/check
+++ b/bin/check
@@ -8,6 +8,7 @@ AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+export AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // empty' /tmp/input)
 export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' /tmp/input)
 
 # remove any empty credentials vars so the AWS client will try instance profiles
@@ -17,6 +18,10 @@ fi
 
 if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
   unset AWS_SECRET_ACCESS_KEY
+fi
+
+if [ -z "$AWS_SESSION_TOKEN" ]; then
+    unset AWS_SESSION_TOKEN
 fi
 
 jq '.source.filters | to_entries | map({"Name": .key, "Values": [(.value|select(type!="array") = [.])|.[]|tostring]})' /tmp/input > /tmp/filters.json

--- a/bin/in
+++ b/bin/in
@@ -10,6 +10,7 @@ AMI=$(jq -r '.version.ami // empty' /tmp/input)
 
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+export AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // empty' /tmp/input)
 export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' /tmp/input)
 
 # remove any empty credentials vars so the AWS client will try instance profiles
@@ -19,6 +20,10 @@ fi
 
 if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
   unset AWS_SECRET_ACCESS_KEY
+fi
+
+if [ -z "$AWS_SESSION_TOKEN" ]; then
+    unset AWS_SESSION_TOKEN
 fi
 
 aws ec2 describe-images --image-ids "$AMI" --query 'Images[0]' \


### PR DESCRIPTION
When using temporary AWS credentials (such as credentials from an assumed role), the AWS CLI requires that `AWS_SESSION_TOKEN` is set in order to validate the credentials. This PR adds the `aws_session_token` variable.